### PR TITLE
Pin version of hwi/oauth-bundle to 2.1 since version 2.2 introduced breaking changes to the authentication failure handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "contao/core-bundle": "^4.13 || ^5.0",
         "contao/manager-plugin": "^2.3.1",
         "doctrine/dbal": "^3.7",
-        "hwi/oauth-bundle": ">=2.1 <2.2",
+        "hwi/oauth-bundle": "2.1.*",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/http-foundation": "^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "contao/core-bundle": "^4.13 || ^5.0",
         "contao/manager-plugin": "^2.3.1",
         "doctrine/dbal": "^3.7",
-        "hwi/oauth-bundle": "^2.1",
+        "hwi/oauth-bundle": ">=2.1 <2.2",
         "symfony/config": "^5.4 || ^6.0",
         "symfony/dependency-injection": "^5.4 || ^6.0",
         "symfony/http-foundation": "^5.4 || ^6.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? |no
| Issues        | 
| License       | MIT

`hwi/oauth-bundle` introduced breaking changes to the authentication failure handling. Until this is sorted out, and we can adapt the bundle to the new failure handling, use the Version 2.1.

See https://github.com/hwi/HWIOAuthBundle/pull/1990