### PR TITLE
Add entry_point config

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -72,6 +72,7 @@ final class Plugin implements BundlePluginInterface, ConfigPluginInterface, Exte
 
         foreach ($extensionConfigs as &$extensionConfig) {
             if (isset($extensionConfig['firewalls']['contao_backend'])) {
+                $extensionConfig['firewalls']['contao_backend']['entry_point'] = 'contao_login';
                 $extensionConfig['firewalls']['contao_backend']['oauth'] = [
                     'resource_owners' => [
                         'contao_id' => '/contao/login/contao_id',

--- a/tests/ContaoManager/PluginTest.php
+++ b/tests/ContaoManager/PluginTest.php
@@ -82,6 +82,7 @@ class PluginTest extends TestCase
         $extensionConfigs = $plugin->getExtensionConfig('security', [['firewalls' => ['contao_backend' => []]]], $container);
 
         $this->assertSame([
+            'entry_point' => 'contao_login',
             'oauth' => [
                 'resource_owners' => [
                     'contao_id' => '/contao/login/contao_id',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 1.x
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

```
In RegisterEntryPointPass.php line 79:
                                                                                                                                                                                                                                                                                         
  Because you have multiple authenticators in firewall "contao_backend", you need to set the "entry_point" key to one of your authenticators ("oauth", "contao_login") or a service ID implementing "Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface". The  
   "entry_point" determines what should happen (e.g. redirect to "/login") when an anonymous user tries to access a protected page.                  
```
