### PR TITLE
Set defaults for env vars

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -46,10 +46,12 @@ final class Plugin implements BundlePluginInterface, ConfigPluginInterface, Exte
         $this->enhanceSecurityConfig($extensionName, $extensionConfigs, $container);
 
         if (!$container->hasParameter('contao_id_identifier')) {
+            $container->setParameter('env(CONTAO_ID_IDENTIFIER)', '');
             $container->setParameter('contao_id_identifier', '%env(CONTAO_ID_IDENTIFIER)%');
         }
 
         if (!$container->hasParameter('contao_id_secret')) {
+            $container->setParameter('env(CONTAO_ID_SECRET)', '');
             $container->setParameter('contao_id_secret', '%env(CONTAO_ID_SECRET)%');
         }
 


### PR DESCRIPTION
When you install this extension and then go directly into the Contao back end and edit a back end user, the following error will occur:

```
Symfony\Component\DependencyInjection\Exception\EnvNotFoundException:
Environment variable not found: "CONTAO_ID_IDENTIFIER".

  at vendor\symfony\dependency-injection\EnvVarProcessor.php:217
  at Symfony\Component\DependencyInjection\EnvVarProcessor->getEnv()
     (vendor\symfony\dependency-injection\Container.php:383)
  at Symfony\Component\DependencyInjection\Container->getEnv()
     (var\cache\dev\ContainerGH2gJ1Z\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer.php:3987)
  at ContainerGH2gJ1Z\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer->getDynamicParameter()
     (var\cache\dev\ContainerGH2gJ1Z\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer.php:3945)
  at ContainerGH2gJ1Z\Contao_ManagerBundle_HttpKernel_ContaoKernelDevDebugContainer->getParameterBag()
     (vendor\contao\contao\core-bundle\contao\library\Contao\Widget.php:1237)
  at Contao\Widget::getAttributesFromDca()
     (vendor\contao\contao\core-bundle\contao\classes\DataContainer.php:481)
  at Contao\DataContainer->row()
     (vendor\contao\contao\core-bundle\contao\drivers\DC_Table.php:2175)
  at Contao\DC_Table->edit()
     (vendor\contao\contao\core-bundle\contao\classes\Backend.php:546)
  at Contao\Backend->getBackendModule()
     (vendor\contao\contao\core-bundle\contao\controllers\BackendMain.php:144)
  at Contao\BackendMain->run()
     (vendor\contao\contao\core-bundle\src\Controller\BackendController.php:44)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor\symfony\http-kernel\HttpKernel.php:181)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor\symfony\http-kernel\HttpKernel.php:76)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor\symfony\http-kernel\Kernel.php:197)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public\index.php:42)                
```

This PR fixes that by providing defaults for the environment variables.

This is the same method used by the `contao/manager-bundle` in its plugin: https://github.com/contao/contao/blob/ab81c7aebc14b671e0a5127804460d5a9709c62f/manager-bundle/src/ContaoManager/Plugin.php#L209

This method is also documented by Symfony here: https://symfony.com/doc/current/configuration/env_var_processors.html#built-in-environment-variable-processors